### PR TITLE
feat:  generating skeleton with unfied config file

### DIFF
--- a/constants.mjs
+++ b/constants.mjs
@@ -1,0 +1,9 @@
+  const constants = {
+ ALLCONFIGPATH:'plop/config.sample.ini'
+ }
+ 
+ export function getConstant(key)
+ {
+    return constants[key]
+ }
+ 

--- a/plop/backend.mjs
+++ b/plop/backend.mjs
@@ -170,32 +170,22 @@ function backendFactory(plop) {
  function setPlopHelpers(plop){
 
   plop.setHelper('UC', function (text) {
-    // if(text && text != '')
-      return text.toUpperCase();
-
-    return text
+    
+    if (!text) return text;
+    
+    return text.toUpperCase();
   });
 
   plop.setHelper('LC', function (text) {
-     if(text && text != '')
-      return text.toLowerCase();
-
-    return text
+    if (!text) return text;
+    
+    return text.toLowerCase();
   });
 
   plop.setHelper('CC', function (text) {
-       if(text && text != '')
-       {
-          if(text.length > 1)
-          {
-              let firstLetter = text.substring(0,1);
-              const rest = text.substring(1, text.length);
-              firstLetter = firstLetter.toLowerCase();
-              return firstLetter + rest;
-          }
-          return text.toLowerCase();
-       }
-      return text;
+    if (!text) return text;
+    if (text.length <= 1) return text.toLowerCase();
+    return text.charAt(0).toLowerCase() + text.slice(1);
   });
 
 }

--- a/plop/backend.mjs
+++ b/plop/backend.mjs
@@ -161,6 +161,36 @@ function backendFactory(plop) {
       ]
     }
   })
+
+  setPlopHelpers(plop)
+}
+
+
+ function setPlopHelpers(plop){
+
+  plop.setHelper('UC', function (text) {
+      return text.toUpperCase();
+  });
+
+  plop.setHelper('LC', function (text) {
+      return text.toLowerCase();
+  });
+
+  plop.setHelper('CC', function (text) {
+      if(text && text != '')
+      {
+          if(text.length > 1)
+          {
+              let firstLetter = text.substring(0,1);
+              const rest = text.substring(1, text.length);
+              firstLetter = firstLetter.toLowerCase();
+              return firstLetter + rest;
+          }
+          return text.toLowerCase();
+      }
+      return text;
+  });
+
 }
 
 export default backendFactory

--- a/plop/backend.mjs
+++ b/plop/backend.mjs
@@ -1,5 +1,6 @@
 import { readFileSync, rm } from 'node:fs'
 import ini from 'ini'
+import  { getConstant }   from '../constants.mjs';
 
 function backendFactory(plop) {
   let outputDir = './plop/output';
@@ -123,7 +124,7 @@ function backendFactory(plop) {
 
       if (answers.configChoice === 'Use sample config') {
         // Load the sample config from the sample-config.ini file
-        const sampleConfig = ini.parse(readFileSync('plop/config.sample.ini', 'utf-8'))
+        const sampleConfig = ini.parse(readFileSync(getConstant('ALLCONFIGPATH'), 'utf-8'))
         configData = { ...sampleConfig }
       } else {
         // Use the answers from the prompts
@@ -169,16 +170,22 @@ function backendFactory(plop) {
  function setPlopHelpers(plop){
 
   plop.setHelper('UC', function (text) {
+    // if(text && text != '')
       return text.toUpperCase();
+
+    return text
   });
 
   plop.setHelper('LC', function (text) {
+     if(text && text != '')
       return text.toLowerCase();
+
+    return text
   });
 
   plop.setHelper('CC', function (text) {
-      if(text && text != '')
-      {
+       if(text && text != '')
+       {
           if(text.length > 1)
           {
               let firstLetter = text.substring(0,1);
@@ -187,7 +194,7 @@ function backendFactory(plop) {
               return firstLetter + rest;
           }
           return text.toLowerCase();
-      }
+       }
       return text;
   });
 

--- a/replacer/scripts/docker-compose/docker-compose-override.mjs
+++ b/replacer/scripts/docker-compose/docker-compose-override.mjs
@@ -7,12 +7,12 @@ const replaces = [
     {
         original: 'looplex.dotnet.samples',
         find: /looplex.dotnet.samples/g,
-        replace: '{{PROJECT_NAMESPACE_LC}}'
+        replace: '{{LC PROJECT_NAMESPACE}}'
     },
     {
         original: 'academic',
         find: /academic/g,
-        replace: '{{MODULE_NAME_LC}}'
+        replace: '{{LC MODULE_NAME}}'
     },
     {
         original: '8080',

--- a/replacer/scripts/docker-compose/docker-compose-override.mjs
+++ b/replacer/scripts/docker-compose/docker-compose-override.mjs
@@ -5,12 +5,12 @@ export const file = 'src/docker/docker-compose.override.yml';
 export const outputFile = '{{PROJECT_PATH}}/docker/docker-compose.override.yml';
 const replaces = [
     {
-        original: 'looplex.dotnet.samples',
+        original: 'Looplex.Dotnet.Samples',
         find: /looplex.dotnet.samples/g,
         replace: '{{LC PROJECT_NAMESPACE}}'
     },
     {
-        original: 'academic',
+        original: 'Academic',
         find: /academic/g,
         replace: '{{LC MODULE_NAME}}'
     },

--- a/replacer/scripts/docker-compose/docker-compose.mjs
+++ b/replacer/scripts/docker-compose/docker-compose.mjs
@@ -5,7 +5,7 @@ export const file = 'src/docker/docker-compose.yml';
 export const outputFile = '{{PROJECT_PATH}}/docker/docker-compose.yml';
 const replaces = [
     {
-        original: 'looplex.dotnet.samples',
+        original: 'Looplex.Dotnet.Samples',
         find: /looplex.dotnet.samples/g,
         replace: '{{LC PROJECT_NAMESPACE}}'
     },
@@ -35,7 +35,7 @@ const replaces = [
         replace: '{{RESOURCE_TYPE_NAME}}'
     },
     {
-        original: 'academic',
+        original: 'Academic',
         find: /academic/g,
         replace: '{{LC MODULE_NAME}}'
     }

--- a/replacer/scripts/docker-compose/docker-compose.mjs
+++ b/replacer/scripts/docker-compose/docker-compose.mjs
@@ -7,7 +7,7 @@ const replaces = [
     {
         original: 'looplex.dotnet.samples',
         find: /looplex.dotnet.samples/g,
-        replace: '{{PROJECT_NAMESPACE_LC}}'
+        replace: '{{LC PROJECT_NAMESPACE}}'
     },
     {
         original: 'Looplex.DotNet.Samples',
@@ -37,7 +37,7 @@ const replaces = [
     {
         original: 'academic',
         find: /academic/g,
-        replace: '{{MODULE_NAME_LC}}'
+        replace: '{{LC MODULE_NAME}}'
     }
   ];
 

--- a/replacer/scripts/service-application-abstractions/csproj.mjs
+++ b/replacer/scripts/service-application-abstractions/csproj.mjs
@@ -3,4 +3,4 @@ import { copyProjectFile } from '../../utils/file-operations.mjs';
 export default copyProjectFile;
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Application.Abstractions/Looplex.DotNet.Samples.Academic.Application.Abstractions.csproj';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.Abstractions/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.Abstractions.csproj';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.Abstractions/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.Abstractions.csproj';

--- a/replacer/scripts/service-application-abstractions/services.istudentservice.mjs
+++ b/replacer/scripts/service-application-abstractions/services.istudentservice.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Application.Abstractions/Services/IStudentService.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.Abstractions/Services/I{{RESOURCE_TYPE_NAME}}Service.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.Abstractions/Services/I{{RESOURCE_TYPE_NAME}}Service.cs';
 const replaces = [
   {
     original: 'Student',

--- a/replacer/scripts/service-application/csproj.mjs
+++ b/replacer/scripts/service-application/csproj.mjs
@@ -15,12 +15,12 @@ const replaces = [
   {
     original: 'academic',
     find: /academic/g,
-    replace: '{{MODULE_NAME_CC}}'
+    replace: '{{CC MODULE_NAME}}'
   }
 ]
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Application/Looplex.DotNet.Samples.Academic.Application.csproj';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.csproj';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.csproj';
 
 
 export default (filePath, outputFilePath) => 

--- a/replacer/scripts/service-application/csproj.mjs
+++ b/replacer/scripts/service-application/csproj.mjs
@@ -5,7 +5,7 @@ const replaces = [
   {
     original: 'Looplex.DotNet.Samples',
     find: /Looplex.DotNet.Samples/g,
-    replace: '{{PROJECT_NAMESPACE}}'
+    replace: '\\{{PROJECT_NAMESPACE}}'
   },
   {
     original: 'Academic',
@@ -13,10 +13,11 @@ const replaces = [
     replace: '{{MODULE_NAME}}'
   },
   {
-    original: 'academic',
+    original: 'Academic',
     find: /academic/g,
     replace: '{{CC MODULE_NAME}}'
   }
+
 ]
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Application/Looplex.DotNet.Samples.Academic.Application.csproj';

--- a/replacer/scripts/service-application/services.studentservice.mjs
+++ b/replacer/scripts/service-application/services.studentservice.mjs
@@ -3,7 +3,7 @@ import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Application/Services/StudentService.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application/Services/{{RESOURCE_TYPE_NAME}}Service.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application/Services/{{RESOURCE_TYPE_NAME}}Service.cs';
 
 const replaces = [
   {
@@ -19,7 +19,7 @@ const replaces = [
   {
       original: 'student',
       find: /student/g,
-      replace: '{{RESOURCE_TYPE_NAME_CC}}'
+      replace: '{{CC RESOURCE_TYPE_NAME}}'
     },
      {
       original: 'Looplex.DotNet.Samples',

--- a/replacer/scripts/service-application/services.studentservice.mjs
+++ b/replacer/scripts/service-application/services.studentservice.mjs
@@ -17,7 +17,7 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'student',
+      original: 'Student',
       find: /student/g,
       replace: '{{CC RESOURCE_TYPE_NAME}}'
     },

--- a/replacer/scripts/service-domain/commands.createstudentcommand.mjs
+++ b/replacer/scripts/service-domain/commands.createstudentcommand.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Commands/CreateStudentCommand.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Commands/Create{{RESOURCE_TYPE_NAME}}Command.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Commands/Create{{RESOURCE_TYPE_NAME}}Command.cs';
 const replaces = [
   {
     original: 'Student',

--- a/replacer/scripts/service-domain/commands.deletestudentcommand.mjs
+++ b/replacer/scripts/service-domain/commands.deletestudentcommand.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Commands/DeleteStudentCommand.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Commands/Delete{{RESOURCE_TYPE_NAME}}Command.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Commands/Delete{{RESOURCE_TYPE_NAME}}Command.cs';
 const replaces = [
   {
     original: 'Student',

--- a/replacer/scripts/service-domain/commands.updatestudentcommand.mjs
+++ b/replacer/scripts/service-domain/commands.updatestudentcommand.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Commands/UpdateStudentCommand.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Commands/Update{{RESOURCE_TYPE_NAME}}Command.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Commands/Update{{RESOURCE_TYPE_NAME}}Command.cs';
 const replaces = [
   {
     original: 'Student',

--- a/replacer/scripts/service-domain/csproj.mjs
+++ b/replacer/scripts/service-domain/csproj.mjs
@@ -16,7 +16,7 @@ const replaces = [
 ]
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Looplex.DotNet.Samples.Academic.Domain.csproj';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain.csproj';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain.csproj';
 export default (filePath, outputFilePath) => 
   CommandProcessor.process({
     filePath,

--- a/replacer/scripts/service-domain/entities.students.project.mjs
+++ b/replacer/scripts/service-domain/entities.students.project.mjs
@@ -2,7 +2,7 @@ import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Entities/Students/Project.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}Child.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}Child.cs';
 const replaces = [
   {
       original: 'Students',

--- a/replacer/scripts/service-domain/entities.students.projecttype.mjs
+++ b/replacer/scripts/service-domain/entities.students.projecttype.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Entities/Students/Project.Type.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}Child.Type.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}Child.Type.cs';
 const replaces = [
   {
       original: 'Students',

--- a/replacer/scripts/service-domain/entities.students.student.mjs
+++ b/replacer/scripts/service-domain/entities.students.student.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Entities/Students/Student.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}.cs';
 const replaces = [
   {
       original: 'Students',

--- a/replacer/scripts/service-domain/entities.students.studenttype.mjs
+++ b/replacer/scripts/service-domain/entities.students.studenttype.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Entities/Students/Student.Type.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}.Type.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Entities/{{RESOURCE_TYPE_NAME_P}}/{{RESOURCE_TYPE_NAME}}.Type.cs';
 const replaces = [
   {
       original: 'Students',

--- a/replacer/scripts/service-domain/queries.getstudentbyidquery.mjs
+++ b/replacer/scripts/service-domain/queries.getstudentbyidquery.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Queries/GetStudentByIdQuery.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Queries/Get{{RESOURCE_TYPE_NAME}}ByIdQuery.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Queries/Get{{RESOURCE_TYPE_NAME}}ByIdQuery.cs';
 const replaces = [
   {
       original: 'Students',

--- a/replacer/scripts/service-domain/queries.getstudentsquery.mjs
+++ b/replacer/scripts/service-domain/queries.getstudentsquery.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Domain/Queries/GetStudentsQuery.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Queries/Get{{RESOURCE_TYPE_NAME_P}}Query.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Domain/Queries/Get{{RESOURCE_TYPE_NAME_P}}Query.cs';
 const replaces = [
   {
       original: 'Students',

--- a/replacer/scripts/service-infra/csproj.mjs
+++ b/replacer/scripts/service-infra/csproj.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Looplex.DotNet.Samples.Academic.Infra.csproj';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra.csproj';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra.csproj';
 const replaces = [
 {
   original: 'Looplex.DotNet.Samples',

--- a/replacer/scripts/service-infra/csproj.mjs
+++ b/replacer/scripts/service-infra/csproj.mjs
@@ -6,7 +6,7 @@ const replaces = [
 {
   original: 'Looplex.DotNet.Samples',
   find: /Looplex.DotNet.Samples/g,
-  replace: '{{PROJECT_NAMESPACE}}'
+  replace: '\\{{PROJECT_NAMESPACE}}'
 },
 {
   original: 'Academic',

--- a/replacer/scripts/service-infra/data.commandhandlers.createstudentcommandhandler.mjs
+++ b/replacer/scripts/service-infra/data.commandhandlers.createstudentcommandhandler.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Data/CommandHandlers/CreateStudentCommandHandler.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/CommandHandlers/Create{{RESOURCE_TYPE_NAME}}CommandHandler.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/CommandHandlers/Create{{RESOURCE_TYPE_NAME}}CommandHandler.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_LCP}}'
+      replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}'
+    replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -46,12 +46,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}children'
+    replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}child'
+    replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }
 ]
 

--- a/replacer/scripts/service-infra/data.commandhandlers.createstudentcommandhandler.mjs
+++ b/replacer/scripts/service-infra/data.commandhandlers.createstudentcommandhandler.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
@@ -44,12 +44,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }

--- a/replacer/scripts/service-infra/data.commandhandlers.deletestudentcommandhandler.mjs
+++ b/replacer/scripts/service-infra/data.commandhandlers.deletestudentcommandhandler.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Data/CommandHandlers/DeleteStudentCommandHandler.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/CommandHandlers/Delete{{RESOURCE_TYPE_NAME}}CommandHandler.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/CommandHandlers/Delete{{RESOURCE_TYPE_NAME}}CommandHandler.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_LCP}}'
+      replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}'
+    replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -46,12 +46,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}children'
+    replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}child'
+    replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }
 ]
 

--- a/replacer/scripts/service-infra/data.commandhandlers.deletestudentcommandhandler.mjs
+++ b/replacer/scripts/service-infra/data.commandhandlers.deletestudentcommandhandler.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
@@ -44,12 +44,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }

--- a/replacer/scripts/service-infra/data.commandhandlers.updatecommandhandler.mjs
+++ b/replacer/scripts/service-infra/data.commandhandlers.updatecommandhandler.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Data/CommandHandlers/UpdateStudentCommandHandler.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/CommandHandlers/Update{{RESOURCE_TYPE_NAME}}CommandHandler.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/CommandHandlers/Update{{RESOURCE_TYPE_NAME}}CommandHandler.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_LCP}}'
+      replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}'
+    replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -46,12 +46,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}children'
+    replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}child'
+    replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }
 ]
 

--- a/replacer/scripts/service-infra/data.commandhandlers.updatecommandhandler.mjs
+++ b/replacer/scripts/service-infra/data.commandhandlers.updatecommandhandler.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
@@ -44,12 +44,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }

--- a/replacer/scripts/service-infra/data.mappers.studentmapper.mjs
+++ b/replacer/scripts/service-infra/data.mappers.studentmapper.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Data/Mappers/StudentMapper.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/Mappers/{{RESOURCE_TYPE_NAME}}Mapper.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/Mappers/{{RESOURCE_TYPE_NAME}}Mapper.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',

--- a/replacer/scripts/service-infra/data.mappers.studentmapper.mjs
+++ b/replacer/scripts/service-infra/data.mappers.studentmapper.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },

--- a/replacer/scripts/service-infra/data.queriehandlers.getstudentbyidqueryhandler.mjs
+++ b/replacer/scripts/service-infra/data.queriehandlers.getstudentbyidqueryhandler.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
@@ -49,7 +49,7 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },

--- a/replacer/scripts/service-infra/data.queriehandlers.getstudentbyidqueryhandler.mjs
+++ b/replacer/scripts/service-infra/data.queriehandlers.getstudentbyidqueryhandler.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Data/QuerieHandlers/GetStudentByIdQueryHandler.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/QueryHandlers/Get{{RESOURCE_TYPE_NAME}}ByIdQueryHandler.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/QueryHandlers/Get{{RESOURCE_TYPE_NAME}}ByIdQueryHandler.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_LCP}}'
+      replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}'
+    replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}children'
+    replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}child'
+    replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }
 ]
 

--- a/replacer/scripts/service-infra/data.queriehandlers.getstudentbyidqueryhandler.mjs
+++ b/replacer/scripts/service-infra/data.queriehandlers.getstudentbyidqueryhandler.mjs
@@ -54,7 +54,7 @@ const replaces = [
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }

--- a/replacer/scripts/service-infra/data.queriehandlers.getstudentsqueryhandler.mjs
+++ b/replacer/scripts/service-infra/data.queriehandlers.getstudentsqueryhandler.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
@@ -49,12 +49,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }

--- a/replacer/scripts/service-infra/data.queriehandlers.getstudentsqueryhandler.mjs
+++ b/replacer/scripts/service-infra/data.queriehandlers.getstudentsqueryhandler.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Data/QuerieHandlers/GetStudentsQueryHandler.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/QueryHandlers/Get{{RESOURCE_TYPE_NAME_P}}QueryHandler.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Data/QueryHandlers/Get{{RESOURCE_TYPE_NAME_P}}QueryHandler.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_LCP}}'
+      replace: '{{LC RESOURCE_TYPE_NAME_P}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}'
+    replace: '{{LC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}children'
+    replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}child'
+    replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }
 ]
 

--- a/replacer/scripts/service-infra/ioc.academicdependencycontainer.mjs
+++ b/replacer/scripts/service-infra/ioc.academicdependencycontainer.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -35,7 +35,7 @@ const replaces = [
   }
   ,
   {
-    original: 'academic',
+    original: 'Academic',
     find: /academic/g,
     replace: '{{CC MODULE_NAME}}'
   }

--- a/replacer/scripts/service-infra/ioc.academicdependencycontainer.mjs
+++ b/replacer/scripts/service-infra/ioc.academicdependencycontainer.mjs
@@ -1,7 +1,7 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
 export const file = 'src/services/academic/Looplex.DotNet.Samples.Academic.Infra/Ioc/AcademicDependencyContainer.cs';
-export const outputFile = '{{PROJECT_PATH}}/services/{{MODULE_NAME_CC}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Ioc/{{MODULE_NAME_CC}}DependencyContainer.cs';
+export const outputFile = '{{PROJECT_PATH}}/services/{{CC MODULE_NAME}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Infra/Ioc/{{CC MODULE_NAME}}DependencyContainer.cs';
 const replaces = [
   {
       original: 'Students',
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -37,7 +37,7 @@ const replaces = [
   {
     original: 'academic',
     find: /academic/g,
-    replace: '{{MODULE_NAME_CC}}'
+    replace: '{{CC MODULE_NAME}}'
   }
 ]
 

--- a/replacer/scripts/test-application-unittests/csproj.mjs
+++ b/replacer/scripts/test-application-unittests/csproj.mjs
@@ -1,10 +1,15 @@
 import { CommandProcessor } from '../../utils/commandProcessor.mjs';
 
-  const replaces = [
+  const replaces = [   
+  {
+    original: 'services\\\\',
+    find: /services/g,
+    replace: 'services\\' 
+  },
   {
     original: 'Looplex.DotNet.Samples',
     find: /Looplex.DotNet.Samples/g,
-    replace: '{{PROJECT_NAMESPACE}}'
+    replace: '\\{{PROJECT_NAMESPACE}}'
   },
   {
     original: 'Academic',
@@ -12,15 +17,16 @@ import { CommandProcessor } from '../../utils/commandProcessor.mjs';
     replace: '{{MODULE_NAME}}'
   },
   {
-    original: 'academic',
+    original: 'Academic',
     find: /academic/g,
     replace: '{{CC MODULE_NAME}}'
   },
   {
     original: 'src',
     find: /src/g,
-    replace: '{{PROJECT_PATH}}'
+    replace: '\\{{PROJECT_PATH}}'
 }
+
 ]
 
 export const file = 'test/Looplex.DotNet.Samples.Academic.Application.UnitTests/Looplex.DotNet.Samples.Academic.Application.UnitTests.csproj';

--- a/replacer/scripts/test-application-unittests/csproj.mjs
+++ b/replacer/scripts/test-application-unittests/csproj.mjs
@@ -14,7 +14,7 @@ import { CommandProcessor } from '../../utils/commandProcessor.mjs';
   {
     original: 'academic',
     find: /academic/g,
-    replace: '{{MODULE_NAME_CC}}'
+    replace: '{{CC MODULE_NAME}}'
   },
   {
     original: 'src',

--- a/replacer/scripts/test-application-unittests/services.studentservicetests.mjs
+++ b/replacer/scripts/test-application-unittests/services.studentservicetests.mjs
@@ -17,12 +17,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -38,7 +38,7 @@ const replaces = [
   {
     original: 'academic',
     find: /academic/g,
-    replace: '{{MODULE_NAME_CC}}'
+    replace: '{{CC MODULE_NAME}}'
   },
   {
     original: 'test',
@@ -57,12 +57,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}children'
+    replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_LC}}child'
+    replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }
 ]
 

--- a/replacer/scripts/test-application-unittests/services.studentservicetests.mjs
+++ b/replacer/scripts/test-application-unittests/services.studentservicetests.mjs
@@ -5,6 +5,11 @@ export const file = 'test/Looplex.DotNet.Samples.Academic.Application.UnitTests/
 export const outputFile = '{{TESTPROJECT_PATH}}/{{PROJECT_NAMESPACE}}.{{MODULE_NAME}}.Application.UnitTests/Services/{{RESOURCE_TYPE_NAME}}ServiceTests.cs';
 const replaces = [
   {
+    original: '\\{{',
+    find: /{{/g,
+    replace: '\\{{'
+  },
+  {
       original: 'Students',
       find: /Students/g,
       replace: '{{RESOURCE_TYPE_NAME_P}}'

--- a/replacer/scripts/test-application-unittests/services.studentservicetests.mjs
+++ b/replacer/scripts/test-application-unittests/services.studentservicetests.mjs
@@ -20,12 +20,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -41,7 +41,7 @@ const replaces = [
   }
   ,
   {
-    original: 'academic',
+    original: 'Academic',
     find: /academic/g,
     replace: '{{CC MODULE_NAME}}'
   },
@@ -60,12 +60,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{LC RESOURCE_TYPE_NAME}}child'
   }

--- a/replacer/scripts/tests-infra-integrationtests/csproj.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/csproj.mjs
@@ -14,19 +14,19 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
     find: /Looplex.DotNet.Samples/g,
-    replace: '{{PROJECT_NAMESPACE}}'
+    replace: '\\{{PROJECT_NAMESPACE}}'
   },
   {
     original: 'Academic',
@@ -34,14 +34,19 @@ const replaces = [
     replace: '{{MODULE_NAME}}'
   },
   {
-    original: 'academic',
+    original: 'Academic',
     find: /academic/g,
     replace: '{{CC MODULE_NAME}}'
   },
   {
     original: 'src',
     find: /src/g,
-    replace: '{{PROJECT_PATH}}'
+    replace: '\\{{PROJECT_PATH}}'
+},
+{
+  original: 'services',
+  find: /services/g,
+  replace: 'services\\'
 }
 ]
 

--- a/replacer/scripts/tests-infra-integrationtests/csproj.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/csproj.mjs
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -36,7 +36,7 @@ const replaces = [
   {
     original: 'academic',
     find: /academic/g,
-    replace: '{{MODULE_NAME_CC}}'
+    replace: '{{CC MODULE_NAME}}'
   },
   {
     original: 'src',

--- a/replacer/scripts/tests-infra-integrationtests/data.commands.CreateStudentCommandHandlerTest.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.commands.CreateStudentCommandHandlerTest.mjs
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Children'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Child'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }
 ]
 

--- a/replacer/scripts/tests-infra-integrationtests/data.commands.CreateStudentCommandHandlerTest.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.commands.CreateStudentCommandHandlerTest.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -49,12 +49,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }

--- a/replacer/scripts/tests-infra-integrationtests/data.commands.DeleteStudentCommandHandlerTest.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.commands.DeleteStudentCommandHandlerTest.mjs
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Children'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Child'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }
 ]
 

--- a/replacer/scripts/tests-infra-integrationtests/data.commands.DeleteStudentCommandHandlerTest.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.commands.DeleteStudentCommandHandlerTest.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -49,12 +49,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }

--- a/replacer/scripts/tests-infra-integrationtests/data.commands.UpdateStudentCommandHandlerTest.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.commands.UpdateStudentCommandHandlerTest.mjs
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Children'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Child'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }
 ]
 

--- a/replacer/scripts/tests-infra-integrationtests/data.commands.UpdateStudentCommandHandlerTest.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.commands.UpdateStudentCommandHandlerTest.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -49,12 +49,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }

--- a/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentByIdQueryHandlerTests.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentByIdQueryHandlerTests.mjs
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Children'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Child'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }
 ]
 

--- a/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentByIdQueryHandlerTests.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentByIdQueryHandlerTests.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -49,12 +49,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }

--- a/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentsQueryHandlerTests.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentsQueryHandlerTests.mjs
@@ -16,12 +16,12 @@ const replaces = [
   {
       original: 'students',
       find: /students/g,
-      replace: '{{RESOURCE_TYPE_NAME_CCP}}'
+      replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
     original: 'student',
     find: /student/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}'
+    replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
   {
     original: 'Looplex.DotNet.Samples',
@@ -51,12 +51,12 @@ const replaces = [
   {
     original: 'projects',
     find: /projects/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Children'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
     original: 'project',
     find: /project/g,
-    replace: '{{RESOURCE_TYPE_NAME_CC}}Child'
+    replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }
 ]
 

--- a/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentsQueryHandlerTests.mjs
+++ b/replacer/scripts/tests-infra-integrationtests/data.queries.GetStudentsQueryHandlerTests.mjs
@@ -14,12 +14,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}'
   },
   {
-      original: 'students',
+      original: 'Students',
       find: /students/g,
       replace: '{{CC RESOURCE_TYPE_NAMEP}}'
   },
   {
-    original: 'student',
+    original: 'Student',
     find: /student/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}'
   },
@@ -49,12 +49,12 @@ const replaces = [
     replace: '{{RESOURCE_TYPE_NAME}}Child'
   },
   {
-    original: 'projects',
+    original: 'Projects',
     find: /projects/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Children'
   },
   {
-    original: 'project',
+    original: 'Project',
     find: /project/g,
     replace: '{{CC RESOURCE_TYPE_NAME}}Child'
   }

--- a/replacer/templates-generator.mjs
+++ b/replacer/templates-generator.mjs
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import readline from 'readline';
 import { pathToFileURL } from 'url';
+import { getConstant }  from '../constants.mjs';
 
 // Setup output directory
 const outputDir = path.resolve('plop/templates');
@@ -57,6 +58,8 @@ async function main() {
   console.log('Output directory cleared.');
 
   const scriptsPath = 'replacer/scripts';
+  fs.writeFileSync(getConstant('ALLCONFIGPATH'), '', { flag: 'w' } );
+ 
   fs.readdirSync(scriptsPath).forEach((dir) => {
     if (fs.lstatSync(path.resolve(scriptsPath, dir)).isDirectory()) {
       const configFile = path.resolve(outputDir, `${dir}.config.ini`)
@@ -76,6 +79,7 @@ async function main() {
         fs.mkdirSync(dirPath, { recursive: true });
         var replaces = replacer.default(filePath, outputFilePath);
 
+        appendToConfig(getConstant('ALLCONFIGPATH'), replaces, getConfigSampleAppendLine)
         appendToConfig(configFile, replaces, getConfigAppendLine);
         appendToConfig(sampleConfigFile, replaces, getConfigSampleAppendLine);
       });

--- a/replacer/templates-generator.mjs
+++ b/replacer/templates-generator.mjs
@@ -96,7 +96,7 @@ function appendToConfig(configFilePath, replaces, appendLineFunc) {
     if (!replace.replace)
       return;
     
-    if (removeBeforeAndAfterMustaches(replace) && !set.has(replace.replace)) {
+    if (removeBeforeAndAfterMustaches(replace) && leaveOnlyConfig(replace) && !set.has(replace.replace)) {
       set.add(replace.replace);
       const appendLine = appendLineFunc(replace);
       fs.appendFileSync(configFilePath, appendLine, 'utf8');
@@ -106,17 +106,26 @@ function appendToConfig(configFilePath, replaces, appendLineFunc) {
     }
   });
 }
-
+//also removes mustaches
 function removeBeforeAndAfterMustaches(replace){
   const startIndex = replace.replace.indexOf('{{');
   const finalIndex = replace.replace.indexOf('}}');
   if(startIndex >= 0 && finalIndex >= 0){
-    replace.replace = replace.replace.substring(startIndex, finalIndex + 2);
+    replace.replace = replace.replace.substring(startIndex +2 , finalIndex);
     return true
   }
   return false
 }
+//config is the last word splited by spaces
+function leaveOnlyConfig(replace){
+  if(replace && replace.replace)
+  {
+    const splited = replace.replace.split(' ');
 
+    replace.replace = splited[splited.length - 1];
+  }
+  return true;
+}
 function getConfigAppendLine(replace) {
   return `${replace.replace}=${replace.replace}\n`
 }

--- a/replacer/templates-generator.mjs
+++ b/replacer/templates-generator.mjs
@@ -108,9 +108,10 @@ function appendToConfig(configFilePath, replaces, appendLineFunc) {
 }
 //also removes mustaches
 function removeBeforeAndAfterMustaches(replace){
+  if (!replace?.replace) return false;
   const startIndex = replace.replace.indexOf('{{');
   const finalIndex = replace.replace.indexOf('}}');
-  if(startIndex >= 0 && finalIndex >= 0){
+  if(startIndex >= 0 && finalIndex >= startIndex){
     replace.replace = replace.replace.substring(startIndex +2 , finalIndex);
     return true
   }
@@ -118,12 +119,12 @@ function removeBeforeAndAfterMustaches(replace){
 }
 //config is the last word splited by spaces
 function leaveOnlyConfig(replace){
-  if(replace && replace.replace)
-  {
-    const splited = replace.replace.split(' ');
 
-    replace.replace = splited[splited.length - 1];
-  }
+  if(!replace?.replace) return false;
+
+  const splited = replace.replace.split(' ');
+  replace.replace = splited[splited.length - 1];
+  
   return true;
 }
 function getConfigAppendLine(replace) {


### PR DESCRIPTION
string cases problem solved
AB#28964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new `constants` module with a `getConstant` function for retrieving configuration paths.
  - Introduced text transformation helpers (`UC`, `LC`, `CC`) for Plop template processing.

- **Improvements**
  - Enhanced configuration file handling and template generation.
  - Updated naming conventions for module and resource type placeholders.
  - Improved case sensitivity in replacement patterns.

- **Code Quality**
  - Refactored template generation logic.
  - Standardized string replacement mechanisms across multiple scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->